### PR TITLE
Namespace multiple workflows

### DIFF
--- a/pkg/bpmn_engine/example_test.go
+++ b/pkg/bpmn_engine/example_test.go
@@ -7,9 +7,10 @@ func ExampleNew() {
 	// register a handler for a service task by Id
 	// and execute the process
 	bpmnEngine := bpmn_engine.New()
-	bpmnEngine.LoadFromFile("test.bpmn.xml")
-	bpmnEngine.AddTaskHandler("aTaskId", myHandler)
-	bpmnEngine.Execute()
+	simpleTask := "simple_task"
+	bpmnEngine.LoadFromFile("test.bpmn.xml", simpleTask)
+	bpmnEngine.AddTaskHandler(simpleTask, "aTaskId", myHandler)
+	bpmnEngine.Execute(simpleTask)
 }
 
 func myHandler(id string) {


### PR DESCRIPTION
Add a resourceName parameter to methods of the BPMN Engine.
Existing states renamed to BpmnEngineNamedResourceState and retain the
same functionality.
New state stores BpmnEngineNamedResourceStates in a map, and the methods
use the resourceName parameter to update the appropriate
BpmnEngineNamedResourceState for a given operation.

Works towards https://github.com/nitram509/lib-bpmn-engine/issues/1. Keen to adjust approach to suit overall project objectives if I've misinterpreted anything.