### PR TITLE
fix #29 findIntermediateCatchEventsForContinuation handle mulit events

### DIFF
--- a/pkg/bpmn_engine/engine.go
+++ b/pkg/bpmn_engine/engine.go
@@ -198,9 +198,10 @@ func (state *BpmnEngineState) findIntermediateCatchEventsForContinuation(process
 				// find potential even definitions
 				for _, ice := range process.definitions.Process.IntermediateCatchEvent {
 					// finally, validate against active subscriptions
+					sub := ice
 					for _, subscription := range state.messageSubscriptions {
 						if subscription.ElementId == ice.Id && subscription.State == activity.Active {
-							ret = append(ret, &ice)
+							ret = append(ret, &sub)
 							break
 						}
 					}


### PR DESCRIPTION
fix #29 findIntermediateCatchEventsForContinuation handle mulit events.

Introuce a local variable to avoid for-range catch the last event.