### PR TITLE
support input/output for service task and user task #2

### DIFF
--- a/docs/supported-elements.md
+++ b/docs/supported-elements.md
@@ -6,10 +6,10 @@ These BPMN elements are supported by the latest release of lib-bpmn-engine.
 * End Event
 * Service Task
     * Get & Set variables from/to context (of the instance)
-    * Evaluating input and output then put them into context (of the instance)
+    * variable mapping (global scope only)
 * User Task
     * equally handled like service tasks
-    * Evaluating input and output then put them into context (of the instance)
+    * variable mapping (global scope only)
 * Forks
     * controlled and uncontrolled forks are supported
     * parallel gateway supported

--- a/docs/supported-elements.md
+++ b/docs/supported-elements.md
@@ -6,8 +6,10 @@ These BPMN elements are supported by the latest release of lib-bpmn-engine.
 * End Event
 * Service Task
     * Get & Set variables from/to context (of the instance)
+    * Evaluating input and output then put them into context (of the instance)
 * User Task
     * equally handled like service tasks
+    * Evaluating input and output then put them into context (of the instance)
 * Forks
     * controlled and uncontrolled forks are supported
     * parallel gateway supported

--- a/pkg/bpmn_engine/engine_jobs.go
+++ b/pkg/bpmn_engine/engine_jobs.go
@@ -55,10 +55,51 @@ func (state *BpmnEngineState) handleServiceTask(process *ProcessInfo, instance *
 			ElementId:                job.ElementId,
 			CreatedAt:                job.CreatedAt,
 		}
+		if err := state.evalInput(instance, job); err != nil {
+			job.State = activity.Failed
+			return false
+		}
 		// TODO retries ...
 		state.handlers[id](activatedJob)
+		if err := state.evalOutput(instance, job); err != nil {
+			job.State = activity.Failed
+			return false
+		}
 	}
 	return job.State == activity.Completed
+}
+
+func (state *BpmnEngineState) evalOutput(instance *ProcessInstanceInfo, job *job) error {
+	for _, v := range instance.GetProcessInfo().definitions.Process.ServiceTasks {
+		if v.Id != job.ElementId {
+			continue
+		}
+		for _, out := range v.Output {
+			evalResult, err := evaluateExpression(out.Source, instance.variableContext)
+			if err != nil {
+				return err
+			}
+			instance.SetVariable(out.Target, evalResult)
+		}
+	}
+	return nil
+}
+
+func (state *BpmnEngineState) evalInput(instance *ProcessInstanceInfo, job *job) error {
+	for _, v := range instance.GetProcessInfo().definitions.Process.ServiceTasks {
+		if v.Id != job.ElementId {
+			continue
+		}
+		for _, in := range v.Input {
+			evalResult, err := evaluateExpression(in.Source, instance.variableContext)
+			if err != nil {
+				job.State = activity.Failed
+				return err
+			}
+			instance.SetVariable(in.Target, evalResult)
+		}
+	}
+	return nil
 }
 
 func findOrCreateJob(jobs []*job, id string, instance *ProcessInstanceInfo, generateKey func() int64) *job {

--- a/pkg/bpmn_engine/engine_jobs_test.go
+++ b/pkg/bpmn_engine/engine_jobs_test.go
@@ -88,3 +88,72 @@ func jobFailHandler(job ActivatedJob) {
 func jobCompleteHandler(job ActivatedJob) {
 	job.Complete()
 }
+
+
+func TestTaskInputOutput(t *testing.T) {
+	// setup
+	bpmnEngine := New("name")
+	cp := CallPath{}
+
+	// give
+	process, _ := bpmnEngine.LoadFromFile("../../test-cases/service-task-input-output.bpmn")
+	bpmnEngine.AddTaskHandler("input-task-1", cp.CallPathHandler)
+	bpmnEngine.AddTaskHandler("input-task-2", cp.CallPathHandler)
+
+	// when
+	pi, err := bpmnEngine.CreateAndRunInstance(process.ProcessKey, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// then
+	for _, job := range bpmnEngine.jobs {
+		then.AssertThat(t, job.State, is.EqualTo(activity.Completed))
+	}
+	then.AssertThat(t, cp.CallPath, is.EqualTo("input-task-1,input-task-2"))
+	then.AssertThat(t, pi.GetVariable("id"), is.EqualTo(1))
+	then.AssertThat(t, pi.GetVariable("orderId"), is.EqualTo(1234))
+	then.AssertThat(t, pi.GetVariable("order"), is.EqualTo(map[string]interface{}{
+		"name": "order1",
+		"id":   "1234",
+	}))
+	then.AssertThat(t, pi.GetVariable("orderName").(string), is.EqualTo("order1"))
+}
+
+func TestInvalidTaskInput(t *testing.T) {
+	// setup
+	bpmnEngine := New("name")
+	cp := CallPath{}
+
+	// give
+	process, _ := bpmnEngine.LoadFromFile("../../test-cases/service-task-invalid-input.bpmn")
+	bpmnEngine.AddTaskHandler("invalid-input", cp.CallPathHandler)
+
+	// when
+	pi, err := bpmnEngine.CreateAndRunInstance(process.ProcessKey, nil)
+	if err != nil {
+		panic(err)
+	}
+	// then
+	then.AssertThat(t, pi.GetVariable("id"), is.EqualTo(nil))
+	then.AssertThat(t, cp.CallPath, is.EqualTo(""))
+}
+
+func TestInvalidTaskOutput(t *testing.T) {
+	// setup
+	bpmnEngine := New("name")
+	cp := CallPath{}
+
+	// give
+	process, _ := bpmnEngine.LoadFromFile("../../test-cases/service-task-invalid-output.bpmn")
+	bpmnEngine.AddTaskHandler("invalid-output", cp.CallPathHandler)
+
+	// when
+	pi, err := bpmnEngine.CreateAndRunInstance(process.ProcessKey, nil)
+	if err != nil {
+		panic(err)
+	}
+	// then
+	then.AssertThat(t, cp.CallPath, is.EqualTo("invalid-output"))
+	then.AssertThat(t, pi.GetVariable("order"), is.EqualTo(nil))
+}

--- a/pkg/bpmn_engine/engine_test.go
+++ b/pkg/bpmn_engine/engine_test.go
@@ -165,3 +165,30 @@ func TestParallelGateWayTwoTasks(t *testing.T) {
 	// then
 	then.AssertThat(t, cp.CallPath, is.EqualTo("id-a-1,id-b-1,id-b-2"))
 }
+
+func TestTaskInputOutput(t *testing.T)  {
+	// setup
+	bpmnEngine := New("name")
+	cp := CallPath{}
+
+	// give
+	process, _ := bpmnEngine.LoadFromFile("../../test-cases/service-task-input-output.bpmn")
+	bpmnEngine.AddTaskHandler("task-1", cp.CallPathHandler)
+	bpmnEngine.AddTaskHandler("task-2", cp.CallPathHandler)
+
+	// when
+	pi, err := bpmnEngine.CreateAndRunInstance(process.ProcessKey, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// then
+	then.AssertThat(t, cp.CallPath, is.EqualTo("task-1,task-2"))
+	then.AssertThat(t, pi.GetVariable("id"), is.EqualTo(1))
+	then.AssertThat(t, pi.GetVariable("orderId"), is.EqualTo(1234))
+	then.AssertThat(t, pi.GetVariable("order"), is.EqualTo(map[string]interface{}{
+		"name": "order1",
+		"id": "1234",
+	}))
+	then.AssertThat(t, pi.GetVariable("orderName").(string), is.EqualTo("order1"))
+}

--- a/pkg/bpmn_engine/engine_test.go
+++ b/pkg/bpmn_engine/engine_test.go
@@ -3,7 +3,6 @@ package bpmn_engine
 import (
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
-	"github.com/nitram509/lib-bpmn-engine/pkg/spec/BPMN20/activity"
 	"testing"
 	"time"
 )
@@ -165,72 +164,4 @@ func TestParallelGateWayTwoTasks(t *testing.T) {
 
 	// then
 	then.AssertThat(t, cp.CallPath, is.EqualTo("id-a-1,id-b-1,id-b-2"))
-}
-
-func TestTaskInputOutput(t *testing.T) {
-	// setup
-	bpmnEngine := New("name")
-	cp := CallPath{}
-
-	// give
-	process, _ := bpmnEngine.LoadFromFile("../../test-cases/service-task-input-output.bpmn")
-	bpmnEngine.AddTaskHandler("input-task-1", cp.CallPathHandler)
-	bpmnEngine.AddTaskHandler("input-task-2", cp.CallPathHandler)
-
-	// when
-	pi, err := bpmnEngine.CreateAndRunInstance(process.ProcessKey, nil)
-	if err != nil {
-		panic(err)
-	}
-
-	// then
-	for _, job := range bpmnEngine.jobs {
-		then.AssertThat(t, job.State, is.EqualTo(activity.Completed))
-	}
-	then.AssertThat(t, cp.CallPath, is.EqualTo("input-task-1,input-task-2"))
-	then.AssertThat(t, pi.GetVariable("id"), is.EqualTo(1))
-	then.AssertThat(t, pi.GetVariable("orderId"), is.EqualTo(1234))
-	then.AssertThat(t, pi.GetVariable("order"), is.EqualTo(map[string]interface{}{
-		"name": "order1",
-		"id":   "1234",
-	}))
-	then.AssertThat(t, pi.GetVariable("orderName").(string), is.EqualTo("order1"))
-}
-
-func TestInvalidTaskInput(t *testing.T) {
-	// setup
-	bpmnEngine := New("name")
-	cp := CallPath{}
-
-	// give
-	process, _ := bpmnEngine.LoadFromFile("../../test-cases/service-task-invalid-input.bpmn")
-	bpmnEngine.AddTaskHandler("invalid-input", cp.CallPathHandler)
-
-	// when
-	pi, err := bpmnEngine.CreateAndRunInstance(process.ProcessKey, nil)
-	if err != nil {
-		panic(err)
-	}
-	// then
-	then.AssertThat(t, pi.GetVariable("id"), is.EqualTo(nil))
-	then.AssertThat(t, cp.CallPath, is.EqualTo(""))
-}
-
-func TestInvalidTaskOutput(t *testing.T) {
-	// setup
-	bpmnEngine := New("name")
-	cp := CallPath{}
-
-	// give
-	process, _ := bpmnEngine.LoadFromFile("../../test-cases/service-task-invalid-output.bpmn")
-	bpmnEngine.AddTaskHandler("invalid-output", cp.CallPathHandler)
-
-	// when
-	pi, err := bpmnEngine.CreateAndRunInstance(process.ProcessKey, nil)
-	if err != nil {
-		panic(err)
-	}
-	// then
-	then.AssertThat(t, cp.CallPath, is.EqualTo("invalid-output"))
-	then.AssertThat(t, pi.GetVariable("order"), is.EqualTo(nil))
 }

--- a/pkg/bpmn_engine/engine_test.go
+++ b/pkg/bpmn_engine/engine_test.go
@@ -3,6 +3,7 @@ package bpmn_engine
 import (
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
+	"github.com/nitram509/lib-bpmn-engine/pkg/spec/BPMN20/activity"
 	"testing"
 	"time"
 )
@@ -166,15 +167,15 @@ func TestParallelGateWayTwoTasks(t *testing.T) {
 	then.AssertThat(t, cp.CallPath, is.EqualTo("id-a-1,id-b-1,id-b-2"))
 }
 
-func TestTaskInputOutput(t *testing.T)  {
+func TestTaskInputOutput(t *testing.T) {
 	// setup
 	bpmnEngine := New("name")
 	cp := CallPath{}
 
 	// give
 	process, _ := bpmnEngine.LoadFromFile("../../test-cases/service-task-input-output.bpmn")
-	bpmnEngine.AddTaskHandler("task-1", cp.CallPathHandler)
-	bpmnEngine.AddTaskHandler("task-2", cp.CallPathHandler)
+	bpmnEngine.AddTaskHandler("input-task-1", cp.CallPathHandler)
+	bpmnEngine.AddTaskHandler("input-task-2", cp.CallPathHandler)
 
 	// when
 	pi, err := bpmnEngine.CreateAndRunInstance(process.ProcessKey, nil)
@@ -183,12 +184,53 @@ func TestTaskInputOutput(t *testing.T)  {
 	}
 
 	// then
-	then.AssertThat(t, cp.CallPath, is.EqualTo("task-1,task-2"))
+	for _, job := range bpmnEngine.jobs {
+		then.AssertThat(t, job.State, is.EqualTo(activity.Completed))
+	}
+	then.AssertThat(t, cp.CallPath, is.EqualTo("input-task-1,input-task-2"))
 	then.AssertThat(t, pi.GetVariable("id"), is.EqualTo(1))
 	then.AssertThat(t, pi.GetVariable("orderId"), is.EqualTo(1234))
 	then.AssertThat(t, pi.GetVariable("order"), is.EqualTo(map[string]interface{}{
 		"name": "order1",
-		"id": "1234",
+		"id":   "1234",
 	}))
 	then.AssertThat(t, pi.GetVariable("orderName").(string), is.EqualTo("order1"))
+}
+
+func TestInvalidTaskInput(t *testing.T) {
+	// setup
+	bpmnEngine := New("name")
+	cp := CallPath{}
+
+	// give
+	process, _ := bpmnEngine.LoadFromFile("../../test-cases/service-task-invalid-input.bpmn")
+	bpmnEngine.AddTaskHandler("invalid-input", cp.CallPathHandler)
+
+	// when
+	pi, err := bpmnEngine.CreateAndRunInstance(process.ProcessKey, nil)
+	if err != nil {
+		panic(err)
+	}
+	// then
+	then.AssertThat(t, pi.GetVariable("id"), is.EqualTo(nil))
+	then.AssertThat(t, cp.CallPath, is.EqualTo(""))
+}
+
+func TestInvalidTaskOutput(t *testing.T) {
+	// setup
+	bpmnEngine := New("name")
+	cp := CallPath{}
+
+	// give
+	process, _ := bpmnEngine.LoadFromFile("../../test-cases/service-task-invalid-output.bpmn")
+	bpmnEngine.AddTaskHandler("invalid-output", cp.CallPathHandler)
+
+	// when
+	pi, err := bpmnEngine.CreateAndRunInstance(process.ProcessKey, nil)
+	if err != nil {
+		panic(err)
+	}
+	// then
+	then.AssertThat(t, cp.CallPath, is.EqualTo("invalid-output"))
+	then.AssertThat(t, pi.GetVariable("order"), is.EqualTo(nil))
 }

--- a/pkg/spec/BPMN20/model.go
+++ b/pkg/spec/BPMN20/model.go
@@ -69,16 +69,18 @@ type TEndEvent struct {
 }
 
 type TServiceTask struct {
-	XMLName             xml.Name `xml:"serviceTask"`
-	Id                  string   `xml:"id,attr"`
-	Name                string   `xml:"name,attr"`
-	Default             string   `xml:"default,attr"`
-	CompletionQuantity  int      `xml:"completionQuantity,attr"`
-	IsForCompensation   bool     `xml:"isForCompensation,attr"`
-	OperationRef        string   `xml:"operationRef,attr"`
-	Implementation      string   `xml:"implementation,attr"`
-	IncomingAssociation []string `xml:"incoming"`
-	OutgoingAssociation []string `xml:"outgoing"`
+	XMLName             xml.Name  `xml:"serviceTask"`
+	Id                  string    `xml:"id,attr"`
+	Name                string    `xml:"name,attr"`
+	Default             string    `xml:"default,attr"`
+	CompletionQuantity  int       `xml:"completionQuantity,attr"`
+	IsForCompensation   bool      `xml:"isForCompensation,attr"`
+	OperationRef        string    `xml:"operationRef,attr"`
+	Implementation      string    `xml:"implementation,attr"`
+	IncomingAssociation []string  `xml:"incoming"`
+	OutgoingAssociation []string  `xml:"outgoing"`
+	Input               []TInput  `xml:"extensionElements>ioMapping>input"`
+	Output              []TOutput `xml:"extensionElements>ioMapping>output"`
 }
 
 type TUserTask struct {
@@ -87,6 +89,16 @@ type TUserTask struct {
 	Name                string   `xml:"name,attr"`
 	IncomingAssociation []string `xml:"incoming"`
 	OutgoingAssociation []string `xml:"outgoing"`
+}
+
+type TInput struct {
+	Source string `xml:"source,attr"`
+	Target string `xml:"target,attr"`
+}
+
+type TOutput struct {
+	Source string `xml:"source,attr"`
+	Target string `xml:"target,attr"`
 }
 
 type TParallelGateway struct {

--- a/test-cases/service-task-input-output.bpmn
+++ b/test-cases/service-task-input-output.bpmn
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1paldd5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.2.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_06j6ykw" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1pv0o34</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="task-1" name="task-1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=&#34;task-1&#34;" target="name" />
+          <zeebe:input source="=1" target="id" />
+          <zeebe:output source="={&#34;name&#34;: &#34;order1&#34;, &#34;id&#34;: &#34;1234&#34;}" target="order" />
+          <zeebe:output source="=1234" target="orderId" />
+        </zeebe:ioMapping>
+        <zeebe:taskDefinition type="task-1" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1pv0o34</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mibmwr</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1pv0o34" sourceRef="StartEvent_1" targetRef="task-1" />
+    <bpmn:serviceTask id="task-2" name="task-2">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=order.name" target="orderName" />
+        </zeebe:ioMapping>
+        <zeebe:taskDefinition type="task-2" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1mibmwr</bpmn:incoming>
+      <bpmn:outgoing>Flow_1imra4b</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1mibmwr" sourceRef="task-1" targetRef="task-2" />
+    <bpmn:endEvent id="Event_1mhay4i">
+      <bpmn:incoming>Flow_1imra4b</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1imra4b" sourceRef="task-2" targetRef="Event_1mhay4i" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_06j6ykw">
+      <bpmndi:BPMNEdge id="Flow_1pv0o34_di" bpmnElement="Flow_1pv0o34">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="340" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mibmwr_di" bpmnElement="Flow_1mibmwr">
+        <di:waypoint x="440" y="120" />
+        <di:waypoint x="530" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1imra4b_di" bpmnElement="Flow_1imra4b">
+        <di:waypoint x="630" y="120" />
+        <di:waypoint x="702" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0296s40_di" bpmnElement="task-1">
+        <dc:Bounds x="340" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_023n1w5_di" bpmnElement="task-2">
+        <dc:Bounds x="530" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1mhay4i_di" bpmnElement="Event_1mhay4i">
+        <dc:Bounds x="702" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test-cases/service-task-invalid-input.bpmn
+++ b/test-cases/service-task-invalid-input.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1paldd5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.2.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="invalid-input" name="invalid-input" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1pv0o34</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="task-1" name="invalid-input">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=iban: &#34;DE456&#34;	" target="id" />
+        </zeebe:ioMapping>
+        <zeebe:taskDefinition type="invalid-input" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1pv0o34</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mibmwr</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1pv0o34" sourceRef="StartEvent_1" targetRef="task-1" />
+    <bpmn:sequenceFlow id="Flow_1mibmwr" sourceRef="task-1" targetRef="Event_1mhay4i" />
+    <bpmn:endEvent id="Event_1mhay4i">
+      <bpmn:incoming>Flow_1mibmwr</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="invalid-input">
+      <bpmndi:BPMNEdge id="Flow_1mibmwr_di" bpmnElement="Flow_1mibmwr">
+        <di:waypoint x="440" y="120" />
+        <di:waypoint x="512" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1pv0o34_di" bpmnElement="Flow_1pv0o34">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="340" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0296s40_di" bpmnElement="task-1">
+        <dc:Bounds x="340" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1mhay4i_di" bpmnElement="Event_1mhay4i">
+        <dc:Bounds x="512" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test-cases/service-task-invalid-output.bpmn
+++ b/test-cases/service-task-invalid-output.bpmn
@@ -4,45 +4,27 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1pv0o34</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:serviceTask id="input-task-1" name="input-task-1">
+    <bpmn:serviceTask id="invalid-output" name="invalid-output">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:input source="=&#34;task-1&#34;" target="name" />
-          <zeebe:input source="=1" target="id" />
-          <zeebe:output source="={&#34;name&#34;: &#34;order1&#34;, &#34;id&#34;: &#34;1234&#34;}" target="order" />
-          <zeebe:output source="=1234" target="orderId" />
+          <zeebe:output source="=iban: &#34;DE456&#34;	" target="order" />
         </zeebe:ioMapping>
-        <zeebe:taskDefinition type="input-task-1" />
+        <zeebe:taskDefinition type="invalid-output" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1pv0o34</bpmn:incoming>
       <bpmn:outgoing>Flow_1mibmwr</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1pv0o34" sourceRef="StartEvent_1" targetRef="input-task-1" />
-    <bpmn:serviceTask id="input-task-2" name="input-task-2">
-      <bpmn:extensionElements>
-        <zeebe:ioMapping>
-          <zeebe:input source="=order.name" target="orderName" />
-        </zeebe:ioMapping>
-        <zeebe:taskDefinition type="input-task-2" />
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1mibmwr</bpmn:incoming>
-      <bpmn:outgoing>Flow_1imra4b</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1mibmwr" sourceRef="input-task-1" targetRef="input-task-2" />
+    <bpmn:sequenceFlow id="Flow_1pv0o34" sourceRef="StartEvent_1" targetRef="invalid-output" />
+    <bpmn:sequenceFlow id="Flow_1mibmwr" sourceRef="invalid-output" targetRef="Event_1mhay4i" />
     <bpmn:endEvent id="Event_1mhay4i">
-      <bpmn:incoming>Flow_1imra4b</bpmn:incoming>
+      <bpmn:incoming>Flow_1mibmwr</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_1imra4b" sourceRef="input-task-2" targetRef="Event_1mhay4i" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_06j6ykw">
-      <bpmndi:BPMNEdge id="Flow_1imra4b_di" bpmnElement="Flow_1imra4b">
-        <di:waypoint x="630" y="120" />
-        <di:waypoint x="702" y="120" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1mibmwr_di" bpmnElement="Flow_1mibmwr">
         <di:waypoint x="440" y="120" />
-        <di:waypoint x="530" y="120" />
+        <di:waypoint x="522" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1pv0o34_di" bpmnElement="Flow_1pv0o34">
         <di:waypoint x="188" y="120" />
@@ -51,16 +33,12 @@
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="152" y="102" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0296s40_di" bpmnElement="input-task-1">
+      <bpmndi:BPMNShape id="Activity_0296s40_di" bpmnElement="invalid-output">
         <dc:Bounds x="340" y="80" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_023n1w5_di" bpmnElement="input-task-2">
-        <dc:Bounds x="530" y="80" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1mhay4i_di" bpmnElement="Event_1mhay4i">
-        <dc:Bounds x="702" y="102" width="36" height="36" />
+        <dc:Bounds x="522" y="102" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
support input/output for service task and user task #2

1. use antonmedv/expr to evaluate exression of input and put them to context
2. only support global scope (instance's context)