### PR TITLE
add TaskDefinition Info for global service task handler

### DIFF
--- a/pkg/bpmn_engine/engine.go
+++ b/pkg/bpmn_engine/engine.go
@@ -34,6 +34,7 @@ func New(name string) BpmnEngineState {
 		processes:            []ProcessInfo{},
 		processInstances:     []*ProcessInstanceInfo{},
 		handlers:             map[string]func(job ActivatedJob){},
+		serviceTaskHandler:   nil,
 		jobs:                 []*job{},
 		messageSubscriptions: []*MessageSubscription{},
 		snowflake:            snowflakeIdGenerator,
@@ -284,6 +285,11 @@ func checkOnlyOneAssociationOrPanic(event *BPMN20.BaseElement) {
 		panic(any(fmt.Sprintf("Element with id=%s has %d incoming associations, but only 1 is supported by this engine.",
 			(*event).GetId(), len((*event).GetIncomingAssociation()))))
 	}
+}
+
+// SetServiceTaskHandler set global service task handler to use task definition info
+func (state *BpmnEngineState) SetServiceTaskHandler(handler func(job ActivatedJob)) {
+	state.serviceTaskHandler = handler
 }
 
 // AddTaskHandler registers a handler function to be called for service tasks with a given taskId

--- a/pkg/bpmn_engine/engine_properties.go
+++ b/pkg/bpmn_engine/engine_properties.go
@@ -24,6 +24,7 @@ type BpmnEngineState struct {
 	timers               []*Timer
 	scheduledFlows       []string
 	handlers             map[string]func(job ActivatedJob)
+	serviceTaskHandler   func(job ActivatedJob)
 	snowflake            *snowflake.Node
 	exporters            []exporter.EventExporter
 }

--- a/pkg/bpmn_engine/engine_test.go
+++ b/pkg/bpmn_engine/engine_test.go
@@ -166,3 +166,15 @@ func TestParallelGateWayTwoTasks(t *testing.T) {
 	// then
 	then.AssertThat(t, cp.CallPath, is.EqualTo("id-a-1,id-b-1,id-b-2"))
 }
+
+func TestServiceTaskTaskDefinitionValue(t *testing.T) {
+	// setup
+	bpmnEngine := New("name")
+	process, _ := bpmnEngine.LoadFromFile("../../test-cases/simple_task.bpmn")
+	// when
+	bpmnEngine.CreateAndRunInstance(process.ProcessKey, nil)
+
+	definition := bpmnEngine.processes[0].definitions.Process.ServiceTasks[0].TaskDefinition
+	then.AssertThat(t, definition.TypeName, is.EqualTo("TestType"))
+	then.AssertThat(t, definition.Retries, is.EqualTo("testValue"))
+}

--- a/pkg/spec/BPMN20/model.go
+++ b/pkg/spec/BPMN20/model.go
@@ -59,17 +59,18 @@ type TEndEvent struct {
 }
 
 type TServiceTask struct {
-	Id                  string       `xml:"id,attr"`
-	Name                string       `xml:"name,attr"`
-	Default             string       `xml:"default,attr"`
-	CompletionQuantity  int          `xml:"completionQuantity,attr"`
-	IsForCompensation   bool         `xml:"isForCompensation,attr"`
-	OperationRef        string       `xml:"operationRef,attr"`
-	Implementation      string       `xml:"implementation,attr"`
-	IncomingAssociation []string     `xml:"incoming"`
-	OutgoingAssociation []string     `xml:"outgoing"`
-	Input               []TIoMapping `xml:"extensionElements>ioMapping>input"`
-	Output              []TIoMapping `xml:"extensionElements>ioMapping>output"`
+	Id                  string          `xml:"id,attr"`
+	Name                string          `xml:"name,attr"`
+	Default             string          `xml:"default,attr"`
+	TaskDefinition      TTaskDefinition `xml:"extensionElements>taskDefinition"`
+	CompletionQuantity  int             `xml:"completionQuantity,attr"`
+	IsForCompensation   bool            `xml:"isForCompensation,attr"`
+	OperationRef        string          `xml:"operationRef,attr"`
+	Implementation      string          `xml:"implementation,attr"`
+	IncomingAssociation []string        `xml:"incoming"`
+	OutgoingAssociation []string        `xml:"outgoing"`
+	Input               []TIoMapping    `xml:"extensionElements>ioMapping>input"`
+	Output              []TIoMapping    `xml:"extensionElements>ioMapping>output"`
 }
 
 type TUserTask struct {
@@ -79,6 +80,11 @@ type TUserTask struct {
 	OutgoingAssociation []string     `xml:"outgoing"`
 	Input               []TIoMapping `xml:"extensionElements>ioMapping>input"`
 	Output              []TIoMapping `xml:"extensionElements>ioMapping>output"`
+}
+
+type TTaskDefinition struct {
+	TypeName string `xml:"type,attr"`
+	Retries  string `xml:"retries,attr"`
 }
 
 type TIoMapping struct {

--- a/test-cases/simple_task.bpmn
+++ b/test-cases/simple_task.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1u3x2yl" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1u3x2yl" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.2.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
   <bpmn:process id="Simple_Task_Process" name="aName" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0xt1d7q</bpmn:outgoing>
@@ -11,7 +11,7 @@
     <bpmn:sequenceFlow id="Flow_1vz4oo2" sourceRef="id" targetRef="Event_1j4mcqg" />
     <bpmn:serviceTask id="id" name="Test">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition type="TestType" />
+        <zeebe:taskDefinition type="TestType" retries="testValue" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0xt1d7q</bpmn:incoming>
       <bpmn:outgoing>Flow_1vz4oo2</bpmn:outgoing>


### PR DESCRIPTION
i am try to use TaskDefinition info for automatic match grpc job service.
I want to replace AddTaskHandler to job service. I think id map is not enough.