### PR TITLE
make explicit engine name optional

### DIFF
--- a/pkg/bpmn_engine/engine.go
+++ b/pkg/bpmn_engine/engine.go
@@ -3,8 +3,11 @@ package bpmn_engine
 import (
 	"errors"
 	"fmt"
-	"github.com/nitram509/lib-bpmn-engine/pkg/bpmn_engine/var_holder"
+	"math/rand"
+	"strconv"
 	"time"
+
+	"github.com/nitram509/lib-bpmn-engine/pkg/bpmn_engine/var_holder"
 
 	"github.com/nitram509/lib-bpmn-engine/pkg/bpmn_engine/exporter"
 	"github.com/nitram509/lib-bpmn-engine/pkg/spec/BPMN20"
@@ -40,6 +43,11 @@ func New(name string) BpmnEngineState {
 		snowflake:            snowflakeIdGenerator,
 		exporters:            []exporter.EventExporter{},
 	}
+}
+// NewWithDefaultName creates an engine with a default name of the engine;
+// useful in case you have multiple ones, in order to distinguish them.
+func NewWithDefaultName() BpmnEngineState {
+	return New("DefaultEngineName"+strconv.Itoa(rand.Intn(1000)))
 }
 
 // CreateInstance creates a new instance for a process with given processKey

--- a/pkg/bpmn_engine/engine_test.go
+++ b/pkg/bpmn_engine/engine_test.go
@@ -166,3 +166,13 @@ func TestParallelGateWayTwoTasks(t *testing.T) {
 	// then
 	then.AssertThat(t, cp.CallPath, is.EqualTo("id-a-1,id-b-1,id-b-2"))
 }
+
+func TestMultipleEnginesCanBeCreatedWithoutAName(t *testing.T) {
+	// when
+
+	bpmnEngine1 := NewWithDefaultName()
+	bpmnEngine2 := NewWithDefaultName()
+
+	// then
+	then.AssertThat(t, bpmnEngine1.name, is.Not(is.EqualTo(bpmnEngine2.name).Reason("make sure the names are different")))
+	}


### PR DESCRIPTION
In order to enable creating an engine without specifying a name (see #71), create the method `NewWithDefaultName()`. The default name is "DefaultEngineName"+A random number from 0 to 1000.  Is this an ok approach for the issue? Where do I document this method?

A different solution would be to rework the `New(name string)` method. For example it can take functions as parameters, as explained [here](https://levelup.gitconnected.com/optional-function-parameter-pattern-in-golang-c1acc829307b).
