### PR TITLE
Marshal variables

### DIFF
--- a/pkg/bpmn_engine/engine.go
+++ b/pkg/bpmn_engine/engine.go
@@ -5,8 +5,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/nitram509/lib-bpmn-engine/pkg/bpmn_engine/var_holder"
-
 	"github.com/nitram509/lib-bpmn-engine/pkg/bpmn_engine/exporter"
 	"github.com/nitram509/lib-bpmn-engine/pkg/spec/BPMN20"
 )
@@ -74,7 +72,7 @@ func (state *BpmnEngineState) CreateInstance(processKey int64, variableContext m
 			processInstanceInfo := processInstanceInfo{
 				ProcessInfo:    process,
 				InstanceKey:    state.generateKey(),
-				VariableHolder: var_holder.New(nil, variableContext),
+				VariableHolder: NewVarHolder(nil, variableContext),
 				CreatedAt:      time.Now(),
 				State:          Ready,
 			}
@@ -369,7 +367,7 @@ func (state *BpmnEngineState) handleIntermediateCatchEvent(process *ProcessInfo,
 		}
 		throwLinkName := (*originActivity.Element()).(BPMN20.TIntermediateThrowEvent).LinkEventDefinition.Name
 		catchLinkName := ice.LinkEventDefinition.Name
-		elementVarHolder := var_holder.New(&instance.VariableHolder, nil)
+		elementVarHolder := NewVarHolder(&instance.VariableHolder, nil)
 		if err := propagateProcessInstanceVariables(&elementVarHolder, ice.Output); err != nil {
 			msg := fmt.Sprintf("Can't evaluate expression in element id=%s name=%s", ice.Id, ice.Name)
 			err = &ExpressionEvaluationError{Msg: msg, Err: err}

--- a/pkg/bpmn_engine/expressions.go
+++ b/pkg/bpmn_engine/expressions.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/antonmedv/expr"
-	"github.com/nitram509/lib-bpmn-engine/pkg/bpmn_engine/var_holder"
 	"github.com/nitram509/lib-bpmn-engine/pkg/spec/BPMN20/extensions"
 )
 
@@ -14,13 +13,13 @@ func evaluateExpression(expression string, variableContext map[string]interface{
 	return expr.Eval(expression, variableContext)
 }
 
-func evaluateLocalVariables(varHolder *var_holder.VariableHolder, mappings []extensions.TIoMapping) error {
+func evaluateLocalVariables(varHolder *VariableHolder, mappings []extensions.TIoMapping) error {
 	return mapVariables(varHolder, mappings, func(key string, value interface{}) {
 		varHolder.SetVariable(key, value)
 	})
 }
 
-func propagateProcessInstanceVariables(varHolder *var_holder.VariableHolder, mappings []extensions.TIoMapping) error {
+func propagateProcessInstanceVariables(varHolder *VariableHolder, mappings []extensions.TIoMapping) error {
 	if len(mappings) == 0 {
 		for k, v := range varHolder.Variables() {
 			varHolder.PropagateVariable(k, v)
@@ -31,7 +30,7 @@ func propagateProcessInstanceVariables(varHolder *var_holder.VariableHolder, map
 	})
 }
 
-func mapVariables(varHolder *var_holder.VariableHolder, mappings []extensions.TIoMapping, setVarFunc func(key string, value interface{})) error {
+func mapVariables(varHolder *VariableHolder, mappings []extensions.TIoMapping, setVarFunc func(key string, value interface{})) error {
 	for _, mapping := range mappings {
 		evalResult, err := evaluateExpression(mapping.Source, varHolder.Variables())
 		if err != nil {

--- a/pkg/bpmn_engine/jobs.go
+++ b/pkg/bpmn_engine/jobs.go
@@ -3,8 +3,6 @@ package bpmn_engine
 import (
 	"time"
 
-	"github.com/nitram509/lib-bpmn-engine/pkg/bpmn_engine/var_holder"
-
 	"github.com/nitram509/lib-bpmn-engine/pkg/spec/BPMN20"
 )
 
@@ -36,7 +34,7 @@ func (state *BpmnEngineState) handleServiceTask(process *ProcessInfo, instance *
 	handler := state.findTaskHandler(element)
 	if handler != nil {
 		job.JobState = Active
-		variableHolder := var_holder.New(&instance.VariableHolder, nil)
+		variableHolder := NewVarHolder(&instance.VariableHolder, nil)
 		activatedJob := &activatedJob{
 			processInstanceInfo:      instance,
 			failHandler:              func(reason string) { job.JobState = Failed },

--- a/pkg/bpmn_engine/jobs_activated.go
+++ b/pkg/bpmn_engine/jobs_activated.go
@@ -2,8 +2,6 @@ package bpmn_engine
 
 import (
 	"time"
-
-	"github.com/nitram509/lib-bpmn-engine/pkg/bpmn_engine/var_holder"
 )
 
 // ActivatedJob is a struct to provide information for registered task handler
@@ -18,7 +16,7 @@ type activatedJob struct {
 	processDefinitionKey     int64
 	elementId                string
 	createdAt                time.Time
-	variableHolder           var_holder.VariableHolder
+	variableHolder           VariableHolder
 }
 
 // ActivatedJob represents an abstraction for the activated job

--- a/pkg/bpmn_engine/links.go
+++ b/pkg/bpmn_engine/links.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/nitram509/lib-bpmn-engine/pkg/bpmn_engine/var_holder"
 	"github.com/nitram509/lib-bpmn-engine/pkg/spec/BPMN20"
 )
 
@@ -19,7 +18,7 @@ func (state *BpmnEngineState) handleIntermediateThrowEvent(process *ProcessInfo,
 	}
 	for _, ice := range process.definitions.Process.IntermediateCatchEvent {
 		if ice.LinkEventDefinition.Name == linkName {
-			elementVarHolder := var_holder.New(&instance.VariableHolder, nil)
+			elementVarHolder := NewVarHolder(&instance.VariableHolder, nil)
 			if err := propagateProcessInstanceVariables(&elementVarHolder, ite.Output); err != nil {
 				msg := fmt.Sprintf("Can't evaluate expression in element id=%s name=%s", ite.Id, ite.Name)
 				nextCommands = []command{errorCommand{

--- a/pkg/bpmn_engine/marshalling_test.go
+++ b/pkg/bpmn_engine/marshalling_test.go
@@ -1,0 +1,34 @@
+package bpmn_engine
+
+import (
+	"fmt"
+	"github.com/corbym/gocrest/is"
+	"testing"
+
+	"github.com/corbym/gocrest/then"
+)
+
+func Test_MarshallEngine(t *testing.T) {
+	bpmnEngine := New()
+	process, _ := bpmnEngine.LoadFromFile("../../test-cases/simple_task-with_output_mapping.bpmn")
+	bpmnEngine.NewTaskHandler().Id("id").Handler(func(job ActivatedJob) {
+		job.SetVariable("valueFromHandler", true)
+		job.SetVariable("otherVariable", "value")
+		job.Complete()
+	})
+	variableContext := make(map[string]interface{})
+	variableContext["hello"] = "world"
+	variableContext["john"] = "doe"
+
+	_, _ = bpmnEngine.CreateAndRunInstance(process.ProcessKey, variableContext)
+
+	data := bpmnEngine.Marshal()
+
+	fmt.Println(string(data))
+
+	bpmnEngine, _ = Unmarshal(data)
+	vars := bpmnEngine.ProcessInstances()[0].VariableHolder
+	then.AssertThat(t, vars.GetVariable("hello"), is.EqualTo("world"))
+	then.AssertThat(t, vars.GetVariable("john"), is.EqualTo("doe"))
+	then.AssertThat(t, vars.GetVariable("valueFromHandler"), is.EqualTo(true))
+}

--- a/pkg/bpmn_engine/process_instance.go
+++ b/pkg/bpmn_engine/process_instance.go
@@ -2,18 +2,16 @@ package bpmn_engine
 
 import (
 	"time"
-
-	"github.com/nitram509/lib-bpmn-engine/pkg/bpmn_engine/var_holder"
 )
 
 // FIXME: shall this be exported?
 type processInstanceInfo struct {
-	ProcessInfo    *ProcessInfo              `json:"-"`
-	InstanceKey    int64                     `json:"ik"`
-	VariableHolder var_holder.VariableHolder `json:"vh,omitempty"`
-	CreatedAt      time.Time                 `json:"c"`
-	State          ActivityState             `json:"s"`
-	CaughtEvents   []catchEvent              `json:"ce,omitempty"`
+	ProcessInfo    *ProcessInfo   `json:"-"`
+	InstanceKey    int64          `json:"ik"`
+	VariableHolder VariableHolder `json:"vh,omitempty"`
+	CreatedAt      time.Time      `json:"c"`
+	State          ActivityState  `json:"s"`
+	CaughtEvents   []catchEvent   `json:"ce,omitempty"`
 	activities     []activity
 }
 

--- a/pkg/bpmn_engine/var_holder.go
+++ b/pkg/bpmn_engine/var_holder.go
@@ -1,14 +1,14 @@
-package var_holder
+package bpmn_engine
 
 type VariableHolder struct {
 	parent    *VariableHolder
 	variables map[string]interface{}
 }
 
-// New creates a new VariableHolder with a given parent and variables map.
+// NewVarHolder creates a new VariableHolder with a given parent and variables map.
 // All variables from parent holder are copied into this one.
 // (hint: the copy is necessary, due to the fact we need to have all variables for expression evaluation in one map)
-func New(parent *VariableHolder, variables map[string]interface{}) VariableHolder {
+func NewVarHolder(parent *VariableHolder, variables map[string]interface{}) VariableHolder {
 	if variables == nil {
 		variables = make(map[string]interface{})
 	}


### PR DESCRIPTION
### Motivation/Abstract

please describe in 1-3 sentences, 
* Variables are not marshaled and loaded back
* This change adds to https://github.com/nitram509/lib-bpmn-engine/issues/12

*Examples: This is a bug fix for ... ; I want to use this BPMN extension attributes 'X' for my project 'Y'...*

### Description/Comments

In this PR I added marshaling for `VariableHolder` when the engine is marshaled and unmarshaled
A unit test is also provided to confirm if the engine is loaded correctly after being marshaled

**Something abnormal that I did:**
I moved VariableHolder to the `bpmn_engine` package. This was to avoid having to put marshaling code in the `var_holder/holder.go` file. I felt like these files are kept so clean with the all the marshaling code in the `mashalling.go` file, I wanted to have the `var_holder/holder.go` file clean of marshaling logic too. I couldn't reference `VariableHolder` properly for marshaling from the `bpmn_engine` package otherwise...

A much smaller change would have been to put the marshaling functions in `var_holder/holder.go`..

### Checklist

Depending on your PR, please ensure the overall consistency/integrity of the project remains.
Please tick just one check item per section below

#### Tests
- [x] did you update or create tests for your code changes?
- [ ] not relevant

#### Code examples
- [ ] did you update or add example code snippets, which relate to your code changes
- [x] not relevant

#### Documentation
- [ ] did you update or create documentation, which relates to your code changes
- [x] not relevant
