### PR TITLE
Add support for marshalling complex variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 docs/build
 site/
 temp.*.json
+vendor

--- a/docs/examples/persistence/persistence.go
+++ b/docs/examples/persistence/persistence.go
@@ -11,8 +11,10 @@ func main() {
 
 	// export the whole engine state as bytes
 	// the export format is valid JSON and can be stored however you want
-	bytes := bpmnEngine.Marshal()
-
+	bytes, err := bpmnEngine.Marshal()
+	if err != nil {
+		panic(err)
+	}
 	// debug print ...
 	println(string(bytes))
 

--- a/pkg/bpmn_engine/marshalling.go
+++ b/pkg/bpmn_engine/marshalling.go
@@ -3,8 +3,12 @@ package bpmn_engine
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/nitram509/lib-bpmn-engine/pkg/spec/BPMN20"
+	"github.com/pbinitiative/feel"
+	"reflect"
+	"strings"
 )
 
 const CurrentSerializerVersion = 1
@@ -210,7 +214,7 @@ func (pii *processInstanceInfo) MarshalJSON() ([]byte, error) {
 		case *eventBasedGatewayActivity:
 			piia.ActivityAdapters = append(piia.ActivityAdapters, createEventBasedGatewayActivityAdapter(activity))
 		default:
-			panic(fmt.Sprintf("[invariant check] missing activity adapter for the type %T", a))
+			return nil, fmt.Errorf("[invariant check] missing activity adapter for the type %T", a)
 		}
 	}
 	return json.Marshal(piia)
@@ -225,8 +229,7 @@ func (pii *processInstanceInfo) UnmarshalJSON(data []byte) error {
 	}
 	pii.ProcessInfo = &ProcessInfo{ProcessKey: adapter.ProcessKey}
 	pii.VariableHolder = adapter.VariableHolder
-	recoverProcessInstanceActivitiesPart1(pii, adapter)
-	return nil
+	return recoverProcessInstanceActivitiesPart1(pii, adapter)
 }
 
 func createEventBasedGatewayActivityAdapter(ebga *eventBasedGatewayActivity) *activityAdapter {
@@ -268,31 +271,255 @@ func (a activitySurrogate) Element() *BPMN20.BaseElement {
 
 // ----------------------------------------------------------------------------
 
-func (state *BpmnEngineState) Marshal() []byte {
+// marshalOptions Options that will be used while marshalling the engine
+type marshalOptions struct {
+	exportTypes bool
+}
+
+// MarshalOption is a function that modifies the marshalOptions
+type MarshalOption func(*marshalOptions) error
+
+// WithMarshalComplexTypes if added as an option the marshaller will export variables with their specific types.
+// When this is used, calls to Unmarshal will need to use RegisterType to configure the types that can be
+// unmarshalled into actual instances
+// .
+// This is useful when you have complex types in your variables that you want to preserve.
+//
+//	Example:
+//	```go
+//	// Marshal with type information
+//	data := engine.Marshal(WithMarshalComplexTypes())
+//
+//	// Unmarshal with type mapping
+//	engine, _ = Unmarshal(data, RegisterType(MyStruct{}))
+//	```
+func WithMarshalComplexTypes() MarshalOption {
+	return func(opts *marshalOptions) error {
+		opts.exportTypes = true
+		return nil
+	}
+}
+
+// applyMarshalOptions Applies the given options and returns the applied marshalOptions
+func applyMarshalOptions(options ...MarshalOption) (*marshalOptions, error) {
+	opts := &marshalOptions{}
+	for _, o := range options {
+		err := o(opts)
+		if err != nil {
+			return nil, fmt.Errorf("could not apply option: %w", err)
+		}
+	}
+
+	return opts, nil
+}
+
+// Marshal marshals the engine into a byte array.
+// Options may be provided to configure the marshalling process.
+// It returns a byte array containing the marshalled engine state.
+// If there is an error applying the options, it will panic.
+//
+// Example:
+//
+//	```go
+//	// Marshal with default options
+//	data, err := bpmn_engine.Marshal()
+//
+//	// Marshal with type information for complex variables
+//	data, err := bpmn_engine.Marshal(WithMarshalComplexTypes())
+//	```
+func (state *BpmnEngineState) Marshal(options ...MarshalOption) ([]byte, error) {
+	opts, err := applyMarshalOptions(options...)
+	if err != nil {
+		return nil, err
+	}
+	pis, err := createProcessInstances(state.processInstances, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	m := serializedBpmnEngine{
 		Version:              CurrentSerializerVersion,
 		Name:                 state.name,
 		MessageSubscriptions: state.messageSubscriptions,
 		ProcessReferences:    createReferences(state.processes),
-		ProcessInstances:     state.processInstances,
+		ProcessInstances:     pis,
 		Timers:               state.timers,
 		Jobs:                 state.jobs,
 	}
 	bytes, err := json.Marshal(m)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return bytes
+	return bytes, nil
+}
+
+// complexVariable this struct is used when marshalling with WithMarshalComplexTypes to export complex types
+type complexVariable struct {
+	Type  string `json:"_t"`
+	Value string `json:"v"`
+}
+
+// newComplexVariable creates a new complexVariable from the given value.
+// The type is derived from the type of the given value. If the type is a pointer, it will be prefixed with "*".
+// The value is the value itself.
+func newComplexVariable(v any) (*complexVariable, error) {
+	t := reflect.TypeOf(v)
+	prefix := ""
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+		prefix = "*"
+	}
+
+	valStr, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return &complexVariable{
+		Type:  fmt.Sprintf("%s%s.%s", prefix, t.PkgPath(), t.Name()),
+		Value: string(valStr),
+	}, nil
+}
+
+// createComplexVariables takes a variable holder and wraps each variable with a complexVariable if the variable is a
+// struct or pointer
+func createComplexVariables(vh VariableHolder) (VariableHolder, error) {
+	for k, v := range vh.variables {
+		kind := reflect.ValueOf(v).Kind()
+		if kind == reflect.Struct || kind == reflect.Ptr {
+			vars, err := newComplexVariable(v)
+			if err != nil {
+				return VariableHolder{}, err
+			}
+			vh.variables[k] = vars
+		}
+	}
+	// If there is a parent, create complex variables for it as well
+	if vh.parent != nil {
+		parent, err := createComplexVariables(*vh.parent)
+		if err != nil {
+			return VariableHolder{}, err
+		}
+		vh.parent = &parent
+	}
+	return vh, nil
+}
+
+// createProcessInstances Creates process instances that can be marshalled to JSON
+func createProcessInstances(pii []*processInstanceInfo, opts *marshalOptions) ([]*processInstanceInfo, error) {
+
+	// If exporting types is not enable, there is nothing extra to do
+	if !opts.exportTypes {
+		return pii, nil
+	}
+
+	// Create complex variables for each process instance
+	for _, pi := range pii {
+		cvs, err := createComplexVariables(pi.VariableHolder)
+		if err != nil {
+			return nil, err
+		}
+		pi.VariableHolder = cvs
+	}
+	return pii, nil
+}
+
+// variableTypeMapping defines a type that can be used to map type keys to actual relection types
+type variableTypeMapping map[string]reflect.Type
+
+// unmarshalOptions Options that will be used while unmarshalling the engine
+type unmarshalOptions struct {
+	exportTypes bool
+	typeMapping variableTypeMapping
+}
+
+// UnmarshalOption is a function that modifies the unmarshalOptions
+type UnmarshalOption func(*unmarshalOptions) error
+
+// registerTypeOption is a function that registers a type in the type mapping
+type registerTypeOption func(map[string]reflect.Type) error
+
+// WithUnmarshalComplexTypes enables type unmarshalling.
+// Additional types can be registered using the RegisterType function.
+func WithUnmarshalComplexTypes(at ...registerTypeOption) UnmarshalOption {
+	// All default complex types that the engine may produce must be registered by default here
+	mappingOptions := []registerTypeOption{
+		RegisterType(feel.FEELDuration{}),
+		RegisterType(feel.FEELDatetime{}),
+		RegisterType(feel.FEELDate{}),
+		RegisterType(feel.FEELTime{}),
+		RegisterType(feel.NullValue{}),
+		RegisterType(feel.Number{}),
+	}
+	mappingOptions = append(mappingOptions, at...)
+
+	return func(opts *unmarshalOptions) error {
+		opts.exportTypes = true
+
+		for _, mo := range mappingOptions {
+			err := mo(opts.typeMapping)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+// RegisterType registers a type that can be unmarshalled into an instance of the given type.
+func RegisterType(instance any) func(map[string]reflect.Type) error {
+	return func(m map[string]reflect.Type) error {
+		t := reflect.TypeOf(instance)
+
+		// Do not allow pointers or any other basic types to be passed in as an instance type
+		// Marshalling and Unmarshalling will take care of pointers
+		if t.Kind() != reflect.Struct {
+			return errors.New("only instance of structs should be used")
+		}
+
+		typeKey := fmt.Sprintf("%s.%s", t.PkgPath(), t.Name())
+		m[typeKey] = t
+		return nil
+	}
+}
+
+// applyUnmarshalOptions Applies the given options and returns the applied unmarshalOptions
+func applyUnmarshalOptions(options ...UnmarshalOption) (*unmarshalOptions, error) {
+	opts := &unmarshalOptions{
+		typeMapping: make(map[string]reflect.Type),
+	}
+	for _, o := range options {
+		err := o(opts)
+		if err != nil {
+			return nil, fmt.Errorf("could not apply option: %w", err)
+		}
+	}
+
+	return opts, nil
 }
 
 // Unmarshal loads the data byte array and creates a new instance of the BPMN Engine
 // Will return an BpmnEngineUnmarshallingError, if there was an issue AND in case of error,
 // the engine return object is only partially initialized and likely not usable
-func Unmarshal(data []byte) (BpmnEngineState, error) {
-	eng := serializedBpmnEngine{}
-	err := json.Unmarshal(data, &eng)
+func Unmarshal(data []byte, opts ...UnmarshalOption) (BpmnEngineState, error) {
+
+	// Build an unmarshalOptions object from the provided options
+	options, err := applyUnmarshalOptions(opts...)
 	if err != nil {
-		panic(err)
+		return BpmnEngineState{}, &BpmnEngineUnmarshallingError{
+			Msg: "Failed to apply unmarshalling options",
+			Err: err,
+		}
+	}
+
+	eng := serializedBpmnEngine{}
+	err = json.Unmarshal(data, &eng)
+	if err != nil {
+		return BpmnEngineState{}, &BpmnEngineUnmarshallingError{
+			Msg: "Failed to unmarshall engine data",
+			Err: err,
+		}
 	}
 	state := New()
 	state.name = eng.Name
@@ -319,12 +546,15 @@ func Unmarshal(data []byte) (BpmnEngineState, error) {
 	}
 	if eng.ProcessInstances != nil {
 		state.processInstances = eng.ProcessInstances
-		err := recoverProcessInstances(&state)
+		err = recoverProcessInstances(&state, options)
 		if err != nil {
 			return state, err
 		}
 	}
-	recoverProcessInstanceActivitiesPart2(&state)
+	err = recoverProcessInstanceActivitiesPart2(&state)
+	if err != nil {
+		return BpmnEngineState{}, err
+	}
 	if eng.MessageSubscriptions != nil {
 		state.messageSubscriptions = eng.MessageSubscriptions
 		err = recoverMessageSubscriptions(&state)
@@ -349,7 +579,7 @@ func Unmarshal(data []byte) (BpmnEngineState, error) {
 	return state, nil
 }
 
-func recoverProcessInstanceActivitiesPart1(pii *processInstanceInfo, adapter *processInstanceInfoAdapter) {
+func recoverProcessInstanceActivitiesPart1(pii *processInstanceInfo, adapter *processInstanceInfoAdapter) error {
 	for _, aa := range adapter.ActivityAdapters {
 		switch aa.Type {
 		case gatewayActivityAdapterType:
@@ -370,12 +600,13 @@ func recoverProcessInstanceActivitiesPart1(pii *processInstanceInfo, adapter *pr
 				OutboundActivityCompleted: aa.OutboundActivityCompleted,
 			})
 		default:
-			panic(fmt.Sprintf("[invariant check] missing recovery code for actictyAdapter.Type=%d", aa.Type))
+			return fmt.Errorf("[invariant check] missing recovery code for actictyAdapter.Type=%d", aa.Type)
 		}
 	}
+	return nil
 }
 
-func recoverProcessInstanceActivitiesPart2(state *BpmnEngineState) {
+func recoverProcessInstanceActivitiesPart2(state *BpmnEngineState) error {
 	for _, pi := range state.processInstances {
 		for _, a := range pi.activities {
 			switch activity := a.(type) {
@@ -384,15 +615,111 @@ func recoverProcessInstanceActivitiesPart2(state *BpmnEngineState) {
 			case *gatewayActivity:
 				activity.element = BPMN20.FindBaseElementsById(&pi.ProcessInfo.definitions, (*a.Element()).GetId())[0]
 			default:
-				panic(fmt.Sprintf("[invariant check] missing case for activity type=%T", a))
+				return fmt.Errorf("[invariant check] missing case for activity type=%T", a)
 			}
 		}
 	}
+	return nil
 }
 
 // ----------------------------------------------------------------------------
 
-func recoverProcessInstances(state *BpmnEngineState) error {
+// newInstance Create a new instance given a type name
+func newInstance(typeName string, opts *unmarshalOptions) any {
+	if strings.HasPrefix(typeName, "*") {
+		// Remove pointer from type name
+		typeName = typeName[1:]
+	}
+
+	t, exists := opts.typeMapping[typeName]
+	if !exists {
+		fmt.Printf("could not find %s\n", typeName)
+		return nil // Type not found
+	}
+	return reflect.New(t).Interface() // Create a new instance (as pointer)
+}
+
+// removePointer Function to remove pointer from an `any` type variable
+func removePointer(v any) (any, bool) {
+	// Use type assertion to check if it's a pointer
+	if ptr, ok := v.(interface{ Elem() any }); ok {
+		return ptr.Elem(), true
+	}
+
+	// Use reflection as a fallback for generic cases
+	return removePointerReflect(v)
+}
+
+// removePointerReflect Function to remove pointer from an `any` type variable
+// using reflection
+func removePointerReflect(v any) (any, bool) {
+	// Use reflection to handle arbitrary pointer types
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Ptr {
+		return rv.Elem().Interface(), true
+	}
+	return v, false
+}
+
+// recoverVariableInstances recovers the variable instances from the given VariableHolder
+func recoverVariableInstances(vh VariableHolder, opts *unmarshalOptions) (VariableHolder, error) {
+	if len(opts.typeMapping) == 0 {
+		// Nothing additional to do
+		return vh, nil
+	}
+
+	for k, v := range vh.variables {
+		if m, ok := v.(map[string]any); ok {
+			typeKey, typeKeyOk := m["_t"]
+			value, valueOk := m["v"]
+			var valueBytes []byte
+
+			if strVal, isString := value.(string); isString {
+				valueBytes = []byte(strVal)
+			} else {
+				valueOk = false
+			}
+
+			// if map has a "_t" key, it's a wrapped variable
+			if typeKeyOk && valueOk {
+				isPointer := false
+				instanceType := typeKey.(string)
+				if strings.HasPrefix(instanceType, "*") {
+					// Remove pointer from type name
+					instanceType = instanceType[1:]
+					isPointer = true
+				}
+
+				// creates a new instance with the type from the map
+				instance := newInstance(instanceType, opts)
+				if instance == nil {
+					return vh, fmt.Errorf("unmarshalling unknown type %s", instanceType)
+				}
+
+				err := json.Unmarshal(valueBytes, instance)
+
+				if err != nil {
+					return vh, err
+				}
+
+				if !isPointer {
+					if val, ok := removePointer(instance); ok {
+						instance = val
+					} else {
+						return vh, errors.New("could not remove pointer")
+					}
+				}
+
+				// Replace the variable with the proper instance
+				vh.variables[k] = instance
+			}
+
+		}
+	}
+	return vh, nil
+}
+
+func recoverProcessInstances(state *BpmnEngineState, opts *unmarshalOptions) error {
 	for i, pi := range state.processInstances {
 		process := state.findProcess(pi.ProcessInfo.ProcessKey)
 		if process == nil {
@@ -402,7 +729,11 @@ func recoverProcessInstances(state *BpmnEngineState) error {
 			}
 		}
 		state.processInstances[i].ProcessInfo = process
-		state.processInstances[i].VariableHolder = pi.VariableHolder
+		vars, err := recoverVariableInstances(pi.VariableHolder, opts)
+		if err != nil {
+			return err
+		}
+		state.processInstances[i].VariableHolder = vars
 	}
 	return nil
 }

--- a/pkg/bpmn_engine/marshalling_test.go
+++ b/pkg/bpmn_engine/marshalling_test.go
@@ -59,6 +59,10 @@ func Test_MarshallEngineComplexVars(t *testing.T) {
 		Name: "pointer",
 		Age:  23,
 	}
+	variableContext["testSlicePtr"] = &[]TestStruct{{
+		Name: "slice",
+		Age:  1,
+	}}
 
 	_, _ = bpmnEngine.CreateAndRunInstance(process.ProcessKey, variableContext)
 
@@ -81,6 +85,72 @@ func Test_MarshallEngineComplexVars(t *testing.T) {
 		Name: "pointer",
 		Age:  23,
 	}))
+	then.AssertThat(t, vars.GetVariable("testSlicePtr"), is.EqualTo(&[]TestStruct{{
+		Name: "slice",
+		Age:  1,
+	}}))
+}
+
+func Test_MarshallEngineComplexVarsSlicePtr(t *testing.T) {
+	bpmnEngine := New()
+	process, _ := bpmnEngine.LoadFromFile("../../test-cases/simple_task-with_output_mapping.bpmn")
+	bpmnEngine.NewTaskHandler().Id("id").Handler(func(job ActivatedJob) {
+		job.Complete()
+	})
+	variableContext := make(map[string]interface{})
+	variableContext["testSlicePtr"] = &[]TestStruct{{
+		Name: "slice",
+		Age:  1,
+	}}
+
+	_, _ = bpmnEngine.CreateAndRunInstance(process.ProcessKey, variableContext)
+
+	data, err := bpmnEngine.Marshal(WithMarshalComplexTypes())
+	then.AssertThat(t, err, is.Nil())
+	fmt.Println(string(data))
+
+	bpmnEngine, err = Unmarshal(data,
+		WithUnmarshalComplexTypes(
+			RegisterType(TestStruct{}),
+		),
+	)
+	then.AssertThat(t, err, is.Empty())
+	vars := bpmnEngine.ProcessInstances()[0].VariableHolder
+	then.AssertThat(t, vars.GetVariable("testSlicePtr"), is.EqualTo(&[]TestStruct{{
+		Name: "slice",
+		Age:  1,
+	}}))
+}
+
+func Test_MarshallEngineComplexVarsSlice(t *testing.T) {
+	bpmnEngine := New()
+	process, _ := bpmnEngine.LoadFromFile("../../test-cases/simple_task-with_output_mapping.bpmn")
+	bpmnEngine.NewTaskHandler().Id("id").Handler(func(job ActivatedJob) {
+		job.Complete()
+	})
+	variableContext := make(map[string]interface{})
+	variableContext["testSlice"] = []TestStruct{{
+		Name: "slice",
+		Age:  1,
+	}}
+
+	_, _ = bpmnEngine.CreateAndRunInstance(process.ProcessKey, variableContext)
+
+	data, err := bpmnEngine.Marshal(WithMarshalComplexTypes())
+	then.AssertThat(t, err, is.Nil())
+	fmt.Println(string(data))
+
+	bpmnEngine, err = Unmarshal(data,
+		WithUnmarshalComplexTypes(
+			RegisterType(TestStruct{}),
+		),
+	)
+	then.AssertThat(t, err, is.Empty())
+	vars := bpmnEngine.ProcessInstances()[0].VariableHolder
+	then.AssertThat(t, vars.GetVariable("testSlice"), is.EqualTo([]TestStruct{{
+		Name: "slice",
+		Age:  1,
+	}}))
 }
 
 func Test_applyUnmarshalOptions(t *testing.T) {

--- a/pkg/bpmn_engine/marshalling_test.go
+++ b/pkg/bpmn_engine/marshalling_test.go
@@ -3,10 +3,17 @@ package bpmn_engine
 import (
 	"fmt"
 	"github.com/corbym/gocrest/is"
+	"github.com/pbinitiative/feel"
+	"reflect"
 	"testing"
 
 	"github.com/corbym/gocrest/then"
 )
+
+type TestStruct struct {
+	Name string `json:"name,omitempty"`
+	Age  int    `json:"age,omitempty"`
+}
 
 func Test_MarshallEngine(t *testing.T) {
 	bpmnEngine := New()
@@ -22,8 +29,8 @@ func Test_MarshallEngine(t *testing.T) {
 
 	_, _ = bpmnEngine.CreateAndRunInstance(process.ProcessKey, variableContext)
 
-	data := bpmnEngine.Marshal()
-
+	data, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 	fmt.Println(string(data))
 
 	bpmnEngine, _ = Unmarshal(data)
@@ -31,4 +38,137 @@ func Test_MarshallEngine(t *testing.T) {
 	then.AssertThat(t, vars.GetVariable("hello"), is.EqualTo("world"))
 	then.AssertThat(t, vars.GetVariable("john"), is.EqualTo("doe"))
 	then.AssertThat(t, vars.GetVariable("valueFromHandler"), is.EqualTo(true))
+}
+
+func Test_MarshallEngineComplexVars(t *testing.T) {
+	bpmnEngine := New()
+	process, _ := bpmnEngine.LoadFromFile("../../test-cases/simple_task-with_output_mapping.bpmn")
+	bpmnEngine.NewTaskHandler().Id("id").Handler(func(job ActivatedJob) {
+		s := job.Variable("testStruct").(TestStruct)
+		p := job.Variable("testPointer").(*TestStruct)
+		fmt.Printf("Name: %s, Age: %d\n", s.Name, s.Age)
+		fmt.Printf("Name: %s, Age: %d\n", p.Name, p.Age)
+		job.Complete()
+	})
+	variableContext := make(map[string]interface{})
+	variableContext["testStruct"] = TestStruct{
+		Name: "struct",
+		Age:  12,
+	}
+	variableContext["testPointer"] = &TestStruct{
+		Name: "pointer",
+		Age:  23,
+	}
+
+	_, _ = bpmnEngine.CreateAndRunInstance(process.ProcessKey, variableContext)
+
+	data, err := bpmnEngine.Marshal(WithMarshalComplexTypes())
+	then.AssertThat(t, err, is.Nil())
+	fmt.Println(string(data))
+
+	bpmnEngine, err = Unmarshal(data,
+		WithUnmarshalComplexTypes(
+			RegisterType(TestStruct{}),
+		),
+	)
+	then.AssertThat(t, err, is.Empty())
+	vars := bpmnEngine.ProcessInstances()[0].VariableHolder
+	then.AssertThat(t, vars.GetVariable("testStruct"), is.EqualTo(TestStruct{
+		Name: "struct",
+		Age:  12,
+	}))
+	then.AssertThat(t, vars.GetVariable("testPointer"), is.EqualTo(&TestStruct{
+		Name: "pointer",
+		Age:  23,
+	}))
+}
+
+func Test_applyUnmarshalOptions(t *testing.T) {
+	type args struct {
+		options []UnmarshalOption
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *unmarshalOptions
+		wantErr bool
+	}{
+		{
+			name: "no options",
+			args: args{
+				options: []UnmarshalOption{},
+			},
+			want: &unmarshalOptions{
+				exportTypes: false,
+				typeMapping: make(map[string]reflect.Type),
+			},
+			wantErr: false,
+		},
+		{
+			name: "With unmarshal complex types",
+			args: args{
+				options: []UnmarshalOption{
+					WithUnmarshalComplexTypes(),
+				},
+			},
+			want: &unmarshalOptions{
+				exportTypes: true,
+				typeMapping: map[string]reflect.Type{
+					"github.com/pbinitiative/feel.FEELDate":     reflect.TypeOf(feel.FEELDate{}),
+					"github.com/pbinitiative/feel.FEELDatetime": reflect.TypeOf(feel.FEELDatetime{}),
+					"github.com/pbinitiative/feel.FEELDuration": reflect.TypeOf(feel.FEELDuration{}),
+					"github.com/pbinitiative/feel.FEELTime":     reflect.TypeOf(feel.FEELTime{}),
+					"github.com/pbinitiative/feel.NullValue":    reflect.TypeOf(feel.NullValue{}),
+					"github.com/pbinitiative/feel.Number":       reflect.TypeOf(feel.Number{}),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "With unmarshal complex types and added type",
+			args: args{
+				options: []UnmarshalOption{
+					WithUnmarshalComplexTypes(
+						RegisterType(TestStruct{}),
+					),
+				},
+			},
+			want: &unmarshalOptions{
+				exportTypes: true,
+				typeMapping: map[string]reflect.Type{
+					"github.com/nitram509/lib-bpmn-engine/pkg/bpmn_engine.TestStruct": reflect.TypeOf(TestStruct{}),
+					"github.com/pbinitiative/feel.FEELDate":                           reflect.TypeOf(feel.FEELDate{}),
+					"github.com/pbinitiative/feel.FEELDatetime":                       reflect.TypeOf(feel.FEELDatetime{}),
+					"github.com/pbinitiative/feel.FEELDuration":                       reflect.TypeOf(feel.FEELDuration{}),
+					"github.com/pbinitiative/feel.FEELTime":                           reflect.TypeOf(feel.FEELTime{}),
+					"github.com/pbinitiative/feel.NullValue":                          reflect.TypeOf(feel.NullValue{}),
+					"github.com/pbinitiative/feel.Number":                             reflect.TypeOf(feel.Number{}),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "With unmarshal complex types giving error",
+			args: args{
+				options: []UnmarshalOption{
+					WithUnmarshalComplexTypes(
+						RegisterType(&TestStruct{}), // Pointer not allowed
+					),
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := applyUnmarshalOptions(tt.args.options...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("applyUnmarshalOptions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("applyUnmarshalOptions() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/tests/marshalling_integration_test.go
+++ b/tests/marshalling_integration_test.go
@@ -32,7 +32,8 @@ func Test_unmarshalled_v1_contains_all_fields(t *testing.T) {
 			then.AssertThat(t, err, is.Nil())
 
 			// when
-			marshalledBytes := engine.Marshal()
+			marshalledBytes, err := engine.Marshal()
+			then.AssertThat(t, err, is.Nil())
 
 			equal, err := JSONBytesEqual(referenceBytes, marshalledBytes)
 			then.AssertThat(t, err, is.Nil())

--- a/tests/marshalling_test.go
+++ b/tests/marshalling_test.go
@@ -34,7 +34,8 @@ func Test_Unmarshal_restores_processKey(t *testing.T) {
 	then.AssertThat(t, err, is.Nil())
 
 	// when
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 
 	// when
 	bpmnEngine, err = bpmn_engine.Unmarshal(bytes)
@@ -51,12 +52,16 @@ func Test_preserve_engine_name(t *testing.T) {
 	originEngine := bpmn_engine.New()
 
 	// given
-	bytes := originEngine.Marshal()
+	bytes, err := originEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
+
 	intermediateEngine, err := bpmn_engine.Unmarshal(bytes)
 	then.AssertThat(t, err, is.Nil())
 
 	// when
-	finalEngine, err := bpmn_engine.Unmarshal(intermediateEngine.Marshal())
+	bytes, err = intermediateEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
+	finalEngine, err := bpmn_engine.Unmarshal(bytes)
 	then.AssertThat(t, err, is.Nil())
 
 	// then
@@ -74,7 +79,8 @@ func Test_Marshal_Unmarshal_Jobs(t *testing.T) {
 	// when
 	instance, err := bpmnEngine.CreateAndRunInstance(pi.ProcessKey, nil)
 	then.AssertThat(t, err, is.Nil())
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, len(bytes), is.GreaterThan(32))
 
 	if enableJsonDataDump {
@@ -107,7 +113,8 @@ func Test_Marshal_Unmarshal_partially_executed_jobs_continue_where_left_of_befor
 	then.AssertThat(t, cp.CallPath, is.EqualTo("id-a-1"))
 
 	instance, err = bpmnEngine.RunOrContinueInstance(instance.InstanceKey)
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, len(bytes), is.GreaterThan(32))
 
 	if enableJsonDataDump {
@@ -142,7 +149,8 @@ func Test_Marshal_Unmarshal_Remain_Handler(t *testing.T) {
 	instance, err := bpmnEngine.CreateInstance(pi.ProcessKey, nil)
 	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, instance.GetState(), is.EqualTo(bpmn_engine.Ready))
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 
 	if enableJsonDataDump {
 		os.WriteFile("temp.marshal.remain.json", bytes, 0644)
@@ -172,7 +180,8 @@ func Test_Marshal_Unmarshal_IntermediateCatchEvents(t *testing.T) {
 	// when
 	_, err = bpmnEngine.CreateAndRunInstance(pi.ProcessKey, nil)
 	then.AssertThat(t, err, is.Nil())
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, len(bytes), is.GreaterThan(32))
 
 	if enableJsonDataDump {
@@ -200,7 +209,8 @@ func Test_Marshal_Unmarshal_IntermediateTimerEvents_timer_is_completing(t *testi
 	// when
 	instance, err := bpmnEngine.CreateAndRunInstance(pi.ProcessKey, nil)
 	then.AssertThat(t, err, is.Nil())
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, len(bytes), is.GreaterThan(32))
 
 	if enableJsonDataDump {
@@ -239,7 +249,8 @@ func Test_Marshal_Unmarshal_IntermediateTimerEvents_message_is_completing(t *tes
 	// when
 	instance, err := bpmnEngine.CreateAndRunInstance(pi.ProcessKey, nil)
 	then.AssertThat(t, err, is.Nil())
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, len(bytes), is.GreaterThan(32))
 
 	// when


### PR DESCRIPTION
### Motivation/Abstract
* Attempts to solve some of the issues of https://github.com/nitram509/lib-bpmn-engine/issues/12, specifically this comment https://github.com/nitram509/lib-bpmn-engine/issues/12#issuecomment-2714391142
* This MR addresses the issue that complex types, such as structs and pointer to structs are not Unmarshalled properly when the engine is loaded back from JSON
* This solution allows the `Marshal` and `Unmarshal` functions to be influenced by providing optional options
* These option allow the `Marshal` to write a slightly more detailed object to json to preserve the original type
* Options for `Unmarshal` is available to configure if complex types should be unmarshalled from the json structure, and optional register custom types that also needs to be unmarshalled if found in json


### Description/Comments

- The options-pattern is used to allow optional configuration of the marshalling and unmarhalling of the engine
- If not additional options are provided the (un)marhalling will work the way it currently does
- If a user of the library wants to configure marshalling complex types it can be done by providing the `WithMarshalComplexTypes` option
- If the user of the library wants to support unmarshalling of complex type it can be enabled providing the `WithUnmarshalComplexTypes`
- `WithUnmarshalComplexTypes` also accepts additional options to register custom types that should also be unmarshalled with `RegisterType`

### Checklist

Depending on your PR, please ensure the overall consistency/integrity of the project remains.
Please tick just one check item per section below

#### Tests
- [x] did you update or create tests for your code changes?
- [ ] not relevant

#### Code examples
- [x] did you update or add example code snippets, which relate to your code changes
- [ ] not relevant

#### Documentation
- [x] did you update or create documentation, which relates to your code changes
- [ ] not relevant
