### PR TITLE
Add support for adding a custom function to marshal/unmarshall variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 docs/build
 site/
 temp.*.json
+vendor

--- a/docs/examples/persistence/persistence.go
+++ b/docs/examples/persistence/persistence.go
@@ -11,8 +11,10 @@ func main() {
 
 	// export the whole engine state as bytes
 	// the export format is valid JSON and can be stored however you want
-	bytes := bpmnEngine.Marshal()
-
+	bytes, err := bpmnEngine.Marshal()
+	if err != nil {
+		panic(err)
+	}
 	// debug print ...
 	println(string(bytes))
 

--- a/pkg/bpmn_engine/marshalling_test.go
+++ b/pkg/bpmn_engine/marshalling_test.go
@@ -1,6 +1,7 @@
 package bpmn_engine
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/corbym/gocrest/is"
 	"testing"
@@ -22,11 +23,68 @@ func Test_MarshallEngine(t *testing.T) {
 
 	_, _ = bpmnEngine.CreateAndRunInstance(process.ProcessKey, variableContext)
 
-	data := bpmnEngine.Marshal()
+	data, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Empty())
 
 	fmt.Println(string(data))
 
 	bpmnEngine, _ = Unmarshal(data)
+	vars := bpmnEngine.ProcessInstances()[0].VariableHolder
+	then.AssertThat(t, vars.GetVariable("hello"), is.EqualTo("world"))
+	then.AssertThat(t, vars.GetVariable("john"), is.EqualTo("doe"))
+	then.AssertThat(t, vars.GetVariable("valueFromHandler"), is.EqualTo(true))
+}
+
+func Test_MarshallEngineWithWrapping(t *testing.T) {
+	bpmnEngine := New()
+	process, _ := bpmnEngine.LoadFromFile("../../test-cases/simple_task-with_output_mapping.bpmn")
+	bpmnEngine.NewTaskHandler().Id("id").Handler(func(job ActivatedJob) {
+		job.SetVariable("valueFromHandler", true)
+		job.SetVariable("otherVariable", "value")
+		job.Complete()
+	})
+	variableContext := make(map[string]interface{})
+	variableContext["hello"] = "world"
+	variableContext["john"] = "doe"
+
+	_, _ = bpmnEngine.CreateAndRunInstance(process.ProcessKey, variableContext)
+
+	type Wrapper struct {
+		Type  string
+		Value any
+	}
+
+	// Simple wrapper function encapsulate a variable into a string
+	wrapVariableFunc := func(_ string, variable any) (any, error) {
+		w := Wrapper{
+			Type:  fmt.Sprintf("%T", variable),
+			Value: variable,
+		}
+
+		v, err := json.Marshal(w)
+		if err != nil {
+			return nil, err
+		}
+
+		return string(v), nil
+	}
+
+	// Simple unwrapper function unwrap a variable from a string
+	unwrapVariableFunc := func(_ string, variable any) (any, error) {
+		w := &Wrapper{}
+		err := json.Unmarshal([]byte(variable.(string)), w)
+		if err != nil {
+			return nil, err
+		}
+		return w.Value, nil
+	}
+
+	data, err := bpmnEngine.Marshal(WithMarshalVariableFunc(wrapVariableFunc))
+	then.AssertThat(t, err, is.Empty())
+
+	fmt.Println(string(data))
+
+	bpmnEngine, _ = Unmarshal(data, WithUnmarshalVariableFunc(unwrapVariableFunc))
 	vars := bpmnEngine.ProcessInstances()[0].VariableHolder
 	then.AssertThat(t, vars.GetVariable("hello"), is.EqualTo("world"))
 	then.AssertThat(t, vars.GetVariable("john"), is.EqualTo("doe"))

--- a/tests/marshalling_integration_test.go
+++ b/tests/marshalling_integration_test.go
@@ -32,7 +32,8 @@ func Test_unmarshalled_v1_contains_all_fields(t *testing.T) {
 			then.AssertThat(t, err, is.Nil())
 
 			// when
-			marshalledBytes := engine.Marshal()
+			marshalledBytes, err := engine.Marshal()
+			then.AssertThat(t, err, is.Nil())
 
 			equal, err := JSONBytesEqual(referenceBytes, marshalledBytes)
 			then.AssertThat(t, err, is.Nil())

--- a/tests/marshalling_test.go
+++ b/tests/marshalling_test.go
@@ -34,7 +34,8 @@ func Test_Unmarshal_restores_processKey(t *testing.T) {
 	then.AssertThat(t, err, is.Nil())
 
 	// when
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 
 	// when
 	bpmnEngine, err = bpmn_engine.Unmarshal(bytes)
@@ -51,12 +52,16 @@ func Test_preserve_engine_name(t *testing.T) {
 	originEngine := bpmn_engine.New()
 
 	// given
-	bytes := originEngine.Marshal()
+	bytes, err := originEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
+
 	intermediateEngine, err := bpmn_engine.Unmarshal(bytes)
 	then.AssertThat(t, err, is.Nil())
 
 	// when
-	finalEngine, err := bpmn_engine.Unmarshal(intermediateEngine.Marshal())
+	bytes, err = intermediateEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
+	finalEngine, err := bpmn_engine.Unmarshal(bytes)
 	then.AssertThat(t, err, is.Nil())
 
 	// then
@@ -74,7 +79,8 @@ func Test_Marshal_Unmarshal_Jobs(t *testing.T) {
 	// when
 	instance, err := bpmnEngine.CreateAndRunInstance(pi.ProcessKey, nil)
 	then.AssertThat(t, err, is.Nil())
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, len(bytes), is.GreaterThan(32))
 
 	if enableJsonDataDump {
@@ -107,7 +113,8 @@ func Test_Marshal_Unmarshal_partially_executed_jobs_continue_where_left_of_befor
 	then.AssertThat(t, cp.CallPath, is.EqualTo("id-a-1"))
 
 	instance, err = bpmnEngine.RunOrContinueInstance(instance.InstanceKey)
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, len(bytes), is.GreaterThan(32))
 
 	if enableJsonDataDump {
@@ -142,7 +149,8 @@ func Test_Marshal_Unmarshal_Remain_Handler(t *testing.T) {
 	instance, err := bpmnEngine.CreateInstance(pi.ProcessKey, nil)
 	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, instance.GetState(), is.EqualTo(bpmn_engine.Ready))
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 
 	if enableJsonDataDump {
 		os.WriteFile("temp.marshal.remain.json", bytes, 0644)
@@ -172,7 +180,8 @@ func Test_Marshal_Unmarshal_IntermediateCatchEvents(t *testing.T) {
 	// when
 	_, err = bpmnEngine.CreateAndRunInstance(pi.ProcessKey, nil)
 	then.AssertThat(t, err, is.Nil())
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, len(bytes), is.GreaterThan(32))
 
 	if enableJsonDataDump {
@@ -200,7 +209,8 @@ func Test_Marshal_Unmarshal_IntermediateTimerEvents_timer_is_completing(t *testi
 	// when
 	instance, err := bpmnEngine.CreateAndRunInstance(pi.ProcessKey, nil)
 	then.AssertThat(t, err, is.Nil())
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, len(bytes), is.GreaterThan(32))
 
 	if enableJsonDataDump {
@@ -239,7 +249,8 @@ func Test_Marshal_Unmarshal_IntermediateTimerEvents_message_is_completing(t *tes
 	// when
 	instance, err := bpmnEngine.CreateAndRunInstance(pi.ProcessKey, nil)
 	then.AssertThat(t, err, is.Nil())
-	bytes := bpmnEngine.Marshal()
+	bytes, err := bpmnEngine.Marshal()
+	then.AssertThat(t, err, is.Nil())
 	then.AssertThat(t, len(bytes), is.GreaterThan(32))
 
 	// when


### PR DESCRIPTION
### Motivation/Abstract

please describe in 1-3 sentences, 
* When marshalling and unmarshalling variables in the `VarHolder`, the original types gets lost. This is a problem when you have complex structures in your variables (e.g structs from a REST Server/Client)
* This change solves it by allowing options to be passed to the `Marshal` and `Unmarshal` functions that gives you an opportunity to change the variable in the `map` just before it is Marshalled, and right after is is Unmarshalled and put back into the map.
* **BREAKING CHANGE**: Removed `panics` from `Marshal` and `Unmarshal` it now returns an `error`


### Description/Comments

* Originally I put all the logic in this library to export type information, but I felt that was a very opinionated solution and added a lot of bloat into this library. Instead I kept the options clean, and give the user the ability to decide if something special needs to be done to a variable
* I've since created another library https://github.com/trojanc/jsonr which works well here in which my opinionated way of wrapping variables are done outside of `lib-bmpn-engine`. It uses reflection and exports the types of items in the VarHolder allowing it to be reconstructed when unmarshalled back from JSON

### Checklist

Depending on your PR, please ensure the overall consistency/integrity of the project remains.
Please tick just one check item per section below

#### Tests
- [x] did you update or create tests for your code changes?
- [ ] not relevant

#### Code examples
- [x] did you update or add example code snippets, which relate to your code changes
- [ ] not relevant

#### Documentation
- [ ] did you update or create documentation, which relates to your code changes
- [ ] not relevant
